### PR TITLE
remove changesets

### DIFF
--- a/.changeset/odd-rats-behave.md
+++ b/.changeset/odd-rats-behave.md
@@ -1,5 +1,0 @@
----
-"google-drive-picker-react": minor
----
-
-better types and scalability


### PR DESCRIPTION
### TL;DR
Removed changeset file for google-drive-picker-react package

### What changed?
Deleted the changeset file `odd-rats-behave.md` which was tracking a minor version bump for improved types and scalability in the google-drive-picker-react package

### How to test?
Verify that the changeset file has been removed from the `.changeset` directory

### Why make this change?
This change is part of the release process, where changeset files are removed after the changes they describe have been published to the package